### PR TITLE
Fix misconfigured --bes_backend option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ to your `~/.bazelrc`, followed by the following set of options that are
 specific to your environment:
 
 ```
-build:mycluster --bes_backend=grpc://fill-in-the-frontend-service-hostname-here:8985
+build:mycluster --bes_backend=grpc://fill-in-the-event-service-hostname-here:8983
 build:mycluster --bes_results_url=http://fill-in-the-browser-service-hostname-here/build_events/bb-event-service/
 build:mycluster --remote_executor=grpc://fill-in-the-frontend-service-hostname-here:8980
 build:mycluster --remote_instance_name=remote-execution

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ to your `~/.bazelrc`, followed by the following set of options that are
 specific to your environment:
 
 ```
-build:mycluster --bes_backend=grpc://fill-in-the-event-service-hostname-here:8983
+build:mycluster --bes_backend=grpc://fill-in-the-event-service-hostname-here:8985
 build:mycluster --bes_results_url=http://fill-in-the-browser-service-hostname-here/build_events/bb-event-service/
 build:mycluster --remote_executor=grpc://fill-in-the-frontend-service-hostname-here:8980
 build:mycluster --remote_instance_name=remote-execution


### PR DESCRIPTION
According to https://docs.bazel.build/versions/master/build-event-protocol.html#the-build-event-service, --bes_backend should point to bb-event-service, not bb-frontend-service. This patch fixes #11