### PR TITLE
Update k8s deployment

### DIFF
--- a/kubernetes/browser.yaml
+++ b/kubernetes/browser.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: browser

--- a/kubernetes/browser.yaml
+++ b/kubernetes/browser.yaml
@@ -22,19 +22,23 @@ spec:
         - containerPort: 80
           protocol: TCP
         volumeMounts:
-        - mountPath: /config/browser.jsonnet
-          name: config
-          subPath: browser.jsonnet
-        - mountPath: /config/common.libsonnet
-          name: common
-          subPath: common.libsonnet
+        - mountPath: /config/
+          name: configs
+          readOnly: true
       volumes:
-      - configMap:
-          name: browser
-        name: config
-      - configMap:
-          name: common
-        name: common
+      - name: configs
+        projected:
+          sources:
+          - configMap:
+              name: browser
+              items:
+              - key: browser.jsonnet
+                path: browser.jsonnet
+          - configMap:
+              name: common
+              items:
+              - key: common.libsonnet
+                path: common.libsonnet
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/browser.yaml
+++ b/kubernetes/browser.yaml
@@ -14,33 +14,41 @@ spec:
         app: browser
     spec:
       containers:
-      - image: buildbarn/bb-browser:20190617T160027Z-548ca96
+      - image: buildbarn/bb-browser:20200102T103638Z-e432c91
         args:
-        - /config/browser.json
+        - /config/browser.jsonnet
         name: browser
         ports:
         - containerPort: 80
           protocol: TCP
         volumeMounts:
-        - mountPath: /config
+        - mountPath: /config/browser.jsonnet
           name: config
+          subPath: browser.jsonnet
+        - mountPath: /config/common.libsonnet
+          name: common
+          subPath: common.libsonnet
       volumes:
       - configMap:
           name: browser
         name: config
+      - configMap:
+          name: common
+        name: common
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  name: browser
+  namespace: buildbarn
   annotations:
     prometheus.io/port: "80"
     prometheus.io/scrape: "true"
-  name: browser
-  namespace: buildbarn
 spec:
   ports:
   - port: 80
     protocol: TCP
+    name: http
   selector:
     app: browser
   type: ClusterIP

--- a/kubernetes/config/browser.yaml
+++ b/kubernetes/config/browser.yaml
@@ -1,71 +1,12 @@
 apiVersion: v1
 data:
-  browser.json: |
+  browser.jsonnet: |
+    local common = import 'common.libsonnet';
+
     {
-      "blobstore": {
-        "contentAddressableStorage": {
-          "sharding": {
-            "hashInitialization": 11946695773637837490,
-            "shard": [
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-0.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-1.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-2.storage:8980"
-                  }
-                },
-                "weight": 1
-              }
-            ]
-          }
-        },
-        "actionCache": {
-          "sharding": {
-            "hashInitialization": 14897363947481274433,
-            "shard": [
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-0.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-1.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-2.storage:8980"
-                  }
-                },
-                "weight": 1
-              }
-            ]
-          }
-        }
-      }
+      blobstore: common.blobstore,
+      maximumMessageSizeBytes: common.maximumMessageSizeBytes,
+      listenAddress: common.httpListenAddress,
     }
 kind: ConfigMap
 metadata:

--- a/kubernetes/config/common.yaml
+++ b/kubernetes/config/common.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+data:
+  common.libsonnet: |
+    {
+      blobstore: {
+        contentAddressableStorage: {
+          sharding: {
+            hashInitialization: 11946695773637837490,
+            shards: [
+              {
+                backend: { grpc: { address: 'storage-0.storage:8981' } },
+                weight: 1,
+              },
+              {
+                backend: { grpc: { address: 'storage-1.storage:8981' } },
+                weight: 1,
+              },
+            ],
+          },
+        },
+        actionCache: {
+          sharding: {
+            hashInitialization: 14897363947481274433,
+            shards: [
+              {
+                backend: { grpc: { address: 'storage-0.storage.buildbarn:8981' } },
+                weight: 1,
+              },
+              {
+                backend: { grpc: { address: 'storage-1.storage.buildbarn:8981' } },
+                weight: 1,
+              },
+            ],
+          },
+        },
+      },
+      # Remember to set your browserUrl to the ingress of the browser deployment
+      # browserUrl: 'http://address-of-bb-browser-ingress:80',
+      maximumMessageSizeBytes: 16 * 1024 * 1024,
+      httpListenAddress: ':80'
+    }
+kind: ConfigMap
+metadata:
+  name: common
+  namespace: buildbarn

--- a/kubernetes/config/event-service.yaml
+++ b/kubernetes/config/event-service.yaml
@@ -1,72 +1,18 @@
 apiVersion: v1
 data:
-  event-service.json: |
+  event-service.jsonnet: |
+    local common = import 'common.libsonnet';
+
     {
-      "blobstore": {
-        "contentAddressableStorage": {
-          "sharding": {
-            "hashInitialization": 11946695773637837490,
-            "shard": [
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-0.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-1.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-2.storage:8980"
-                  }
-                },
-                "weight": 1
-              }
-            ]
-          }
-        },
-        "actionCache": {
-          "sharding": {
-            "hashInitialization": 14897363947481274433,
-            "shard": [
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-0.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-1.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-2.storage:8980"
-                  }
-                },
-                "weight": 1
-              }
-            ]
-          }
-        }
-      }
+      blobstore: common.blobstore,
+      httpListenAddress: common.httpListenAddress,
+      grpcServers: [{
+        listenAddresses: [':8985'],
+        authenticationPolicy: { allow: {} },
+      }],
+      maximumMessageSizeBytes: common.maximumMessageSizeBytes,
     }
+
 kind: ConfigMap
 metadata:
   name: event-service

--- a/kubernetes/config/frontend.yaml
+++ b/kubernetes/config/frontend.yaml
@@ -1,74 +1,20 @@
 apiVersion: v1
 data:
-  frontend.json: |
+  frontend.jsonnet: |
+    local common = import 'common.libsonnet';
+
     {
-      "blobstore": {
-        "contentAddressableStorage": {
-          "sharding": {
-            "hashInitialization": 11946695773637837490,
-            "shard": [
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-0.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-1.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-2.storage:8980"
-                  }
-                },
-                "weight": 1
-              }
-            ]
-          }
-        },
-        "actionCache": {
-          "sharding": {
-            "hashInitialization": 14897363947481274433,
-            "shard": [
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-0.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-1.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-2.storage:8980"
-                  }
-                },
-                "weight": 1
-              }
-            ]
-          }
-        }
+      blobstore: common.blobstore,
+      httpListenAddress: common.httpListenAddress,
+      grpcServers: [{
+        listenAddresses: [':8980'],
+        authenticationPolicy: { allow: {} },
+      }],
+      schedulers: {
+        'remote-execution': { address: 'scheduler:8982' },
       },
-      "schedulers": {
-        "ubuntu16-04": "scheduler-ubuntu16-04:8981"
-      }
+      verifyActionResultCompleteness: true,
+      maximumMessageSizeBytes: common.maximumMessageSizeBytes,
     }
 kind: ConfigMap
 metadata:

--- a/kubernetes/config/runner-ubuntu16-04.yaml
+++ b/kubernetes/config/runner-ubuntu16-04.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  runner-ubuntu16-04.jsonnet: |
+    {
+      buildDirectoryPath: '/worker/build',
+      grpcServers: [{
+        listenPaths: ['/worker/runner'],
+        authenticationPolicy: { allow: {} },
+      }],
+    }
+kind: ConfigMap
+metadata:
+  name: runner-ubuntu16-04
+  namespace: buildbarn

--- a/kubernetes/config/runner.yaml
+++ b/kubernetes/config/runner.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-data:
-  runner.json: |
-    {}
-kind: ConfigMap
-metadata:
-  name: runner
-  namespace: buildbarn

--- a/kubernetes/config/scheduler.yaml
+++ b/kubernetes/config/scheduler.yaml
@@ -1,7 +1,20 @@
 apiVersion: v1
 data:
-  scheduler.json: |
-    {}
+  scheduler.jsonnet: |
+    local common = import 'common.libsonnet';
+
+    {
+      httpListenAddress: common.httpListenAddress,
+      clientGrpcServers: [{
+        listenAddresses: [':8982'],
+        authenticationPolicy: { allow: {} },
+      }],
+      workerGrpcServers: [{
+        listenAddresses: [':8983'],
+        authenticationPolicy: { allow: {} },
+      }],
+      blobstore: common.blobstore,
+    }
 kind: ConfigMap
 metadata:
   name: scheduler

--- a/kubernetes/config/storage.yaml
+++ b/kubernetes/config/storage.yaml
@@ -1,29 +1,37 @@
 apiVersion: v1
 data:
-  storage.json: |
+  storage.jsonnet: |
+    local common = import 'common.libsonnet';
+
     {
-      "blobstore": {
-        "contentAddressableStorage": {
-          "circular": {
-            "directory": "/cas",
-            "offsetFileSizeBytes": 16777216,
-            "offsetCacheSize": 10000,
-            "dataFileSizeBytes": 10737418240,
-            "dataAllocationChunkSizeBytes": 16777216
-          }
+      blobstore: {
+        contentAddressableStorage: {
+          circular: {
+            directory: '/cas',
+            offsetFileSizeBytes: 16 * 1024 * 1024,
+            offsetCacheSize: 10000,
+            dataFileSizeBytes: 10 * 1024 * 1024 * 1024,
+            dataAllocationChunkSizeBytes: 16 * 1024 * 1024,
+          },
         },
-        "actionCache": {
-          "circular": {
-            "directory": "/ac",
-            "offsetFileSizeBytes": 1048576,
-            "offsetCacheSize": 1000,
-            "dataFileSizeBytes": 104857600,
-            "dataAllocationChunkSizeBytes": 1048576,
-            "instance": ["bb-event-service", "ubuntu16-04"]
-          }
-        }
+        actionCache: {
+          circular: {
+            directory: '/ac',
+            offsetFileSizeBytes: 1024 * 1024,
+            offsetCacheSize: 1000,
+            dataFileSizeBytes: 100 * 1024 * 1024,
+            dataAllocationChunkSizeBytes: 1024 * 1024,
+            instances: ['bb-event-service', 'remote-execution'],
+          },
+        },
       },
-      "allowAcUpdatesForInstances": ["bb-event-service", "ubuntu16-04"]
+      httpListenAddress: common.httpListenAddress,
+      grpcServers: [{
+        listenAddresses: [':8981'],
+        authenticationPolicy: { allow: {} },
+      }],
+      allowAcUpdatesForInstances: ['bb-event-service', 'remote-execution'],
+      maximumMessageSizeBytes: common.maximumMessageSizeBytes,
     }
 
 kind: ConfigMap

--- a/kubernetes/config/worker-ubuntu16-04.yaml
+++ b/kubernetes/config/worker-ubuntu16-04.yaml
@@ -1,75 +1,40 @@
 apiVersion: v1
 data:
-  worker.json: |
+  worker-ubuntu16-04.jsonnet: |
+    local common = import 'common.libsonnet';
+
     {
-      "blobstore": {
-        "contentAddressableStorage": {
-          "sharding": {
-            "hashInitialization": 11946695773637837490,
-            "shard": [
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-0.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-1.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-2.storage:8980"
-                  }
-                },
-                "weight": 1
-              }
-            ]
-          }
-        },
-        "actionCache": {
-          "sharding": {
-            "hashInitialization": 14897363947481274433,
-            "shard": [
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-0.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-1.storage:8980"
-                  }
-                },
-                "weight": 1
-              },
-              {
-                "backend": {
-                  "grpc": {
-                    "endpoint": "storage-2.storage:8980"
-                  }
-                },
-                "weight": 1
-              }
-            ]
-          }
-        }
+      blobstore: common.blobstore,
+      maximumMessageSizeBytes: common.maximumMessageSizeBytes,
+      scheduler: { address: 'scheduler:8983' },
+      httpListenAddress: common.httpListenAddress,
+      maximumMemoryCachedDirectories: 1000,
+      localBuildDirectory: {
+        buildDirectoryPath: '/worker/build',
+        cacheDirectoryPath: '/worker/cache',
+        maximumCacheFileCount: 10000,
+        maximumCacheSizeBytes: 1024 * 1024 * 1024,
+        cacheReplacementPolicy: 'LEAST_RECENTLY_USED',
       },
-      "browserUrl": "http://bb-browser.example.com/",
-      "concurrency": 4,
-      "schedulerAddress": "scheduler-ubuntu16-04:8981"
+      instanceName: 'remote-execution',
+      runners: [{
+        endpoint: { address: 'unix:///worker/runner' },
+        concurrency: 8,
+        platform: {
+          properties: [
+            { name: 'OSFamily', value: 'Linux' },
+            { name: 'container-image', value: 'docker://marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:6ad1d0883742bfd30eba81e292c135b95067a6706f3587498374a083b7073cb9' },
+          ],
+        },
+        defaultExecutionTimeout: '1800s',
+        maximumExecutionTimeout: '3600s',
+        workerId: {
+          'pod': std.extVar("POD_NAME"),
+          'node': std.extVar("NODE_NAME")
+        },
+      }],
     }
+
 kind: ConfigMap
 metadata:
   name: worker-ubuntu16-04

--- a/kubernetes/event-service.yaml
+++ b/kubernetes/event-service.yaml
@@ -14,20 +14,27 @@ spec:
         app: event-service
     spec:
       containers:
-      - image: buildbarn/bb-event-service:20190617T160116Z-3ab3681
+      - image: buildbarn/bb-event-service:20200102T104139Z-c01f79c
         args:
-        - /config/event-service.json
+        - /config/event-service.jsonnet
         name: event-service
         ports:
-        - containerPort: 8983
+        - containerPort: 8985
           protocol: TCP
         volumeMounts:
-        - mountPath: /config
+        - mountPath: /config/event-service.jsonnet
           name: config
+          subPath: event-service.jsonnet
+        - mountPath: /config/common.libsonnet
+          name: common
+          subPath: common.libsonnet
       volumes:
       - configMap:
           name: event-service
         name: config
+      - configMap:
+          name: common
+        name: common
 ---
 apiVersion: v1
 kind: Service
@@ -39,8 +46,9 @@ metadata:
   namespace: buildbarn
 spec:
   ports:
-  - port: 8983
+  - port: 8985
     protocol: TCP
+    name: grpc
   selector:
     app: event-service
   type: LoadBalancer

--- a/kubernetes/event-service.yaml
+++ b/kubernetes/event-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: event-service

--- a/kubernetes/frontend.yaml
+++ b/kubernetes/frontend.yaml
@@ -15,19 +15,26 @@ spec:
     spec:
       containers:
       - args:
-        - /config/frontend.json
-        image: buildbarn/bb-storage:20190617T155413Z-3c42fa4
+        - /config/frontend.jsonnet
+        image: buildbarn/bb-storage:20200102T100452Z-f920d92
         name: storage
         ports:
         - containerPort: 8980
           protocol: TCP
         volumeMounts:
-        - mountPath: /config
+        - mountPath: /config/frontend.jsonnet
           name: config
+          subPath: frontend.jsonnet
+        - mountPath: /config/common.libsonnet
+          name: common
+          subPath: common.libsonnet
       volumes:
       - configMap:
           name: frontend
         name: config
+      - configMap:
+          name: common
+        name: common
 ---
 apiVersion: v1
 kind: Service
@@ -41,6 +48,7 @@ spec:
   ports:
   - port: 8980
     protocol: TCP
+    name: grpc
   selector:
     app: frontend
   type: LoadBalancer

--- a/kubernetes/frontend.yaml
+++ b/kubernetes/frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend

--- a/kubernetes/frontend.yaml
+++ b/kubernetes/frontend.yaml
@@ -22,19 +22,23 @@ spec:
         - containerPort: 8980
           protocol: TCP
         volumeMounts:
-        - mountPath: /config/frontend.jsonnet
-          name: config
-          subPath: frontend.jsonnet
-        - mountPath: /config/common.libsonnet
-          name: common
-          subPath: common.libsonnet
+        - mountPath: /config/
+          name: configs
+          readOnly: true
       volumes:
-      - configMap:
-          name: frontend
-        name: config
-      - configMap:
-          name: common
-        name: common
+      - name: configs
+        projected:
+          sources:
+          - configMap:
+              name: frontend
+              items:
+              - key: frontend.jsonnet
+                path: frontend.jsonnet
+          - configMap:
+              name: common
+              items:
+              - key: common.libsonnet
+                path: common.libsonnet
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/scheduler.yaml
+++ b/kubernetes/scheduler.yaml
@@ -17,32 +17,50 @@ spec:
     spec:
       containers:
       - args:
-        - /config/scheduler.json
-        image: buildbarn/bb-scheduler:20190617T153934Z-810b6b8
+        - /config/scheduler.jsonnet
+        image: buildbarn/bb-scheduler:20200102T102244Z-300a067
         name: scheduler
         ports:
-        - containerPort: 8981
+        - containerPort: 8982
+          protocol: TCP
+        - containerPort: 8983
+          protocol: TCP
+        - containerPort: 80
           protocol: TCP
         volumeMounts:
-        - mountPath: /config
+        - mountPath: /config/scheduler.jsonnet
           name: config
+          subPath: scheduler.jsonnet
+        - mountPath: /config/common.libsonnet
+          name: common
+          subPath: common.libsonnet
       volumes:
       - configMap:
           name: scheduler
         name: config
+      - configMap:
+          name: common
+        name: common
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  name: scheduler
+  namespace: buildbarn
   annotations:
     prometheus.io/port: "80"
     prometheus.io/scrape: "true"
-  name: scheduler-ubuntu16-04
-  namespace: buildbarn
 spec:
   ports:
-  - port: 8981
+  - port: 8982
     protocol: TCP
+    name: client-grpc
+  - port: 8983
+    protocol: TCP
+    name: worker-grpc
+  - port: 80
+    protocol: TCP
+    name: http
   selector:
     app: scheduler
     instance: ubuntu16-04

--- a/kubernetes/scheduler.yaml
+++ b/kubernetes/scheduler.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: scheduler-ubuntu16-04

--- a/kubernetes/scheduler.yaml
+++ b/kubernetes/scheduler.yaml
@@ -28,19 +28,23 @@ spec:
         - containerPort: 80
           protocol: TCP
         volumeMounts:
-        - mountPath: /config/scheduler.jsonnet
-          name: config
-          subPath: scheduler.jsonnet
-        - mountPath: /config/common.libsonnet
-          name: common
-          subPath: common.libsonnet
+        - mountPath: /config/
+          name: configs
+          readOnly: true
       volumes:
-      - configMap:
-          name: scheduler
-        name: config
-      - configMap:
-          name: common
-        name: common
+      - name: configs
+        projected:
+          sources:
+          - configMap:
+              name: scheduler
+              items:
+              - key: scheduler.jsonnet
+                path: scheduler.jsonnet
+          - configMap:
+              name: common
+              items:
+              - key: common.libsonnet
+                path: common.libsonnet
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/storage.yaml
+++ b/kubernetes/storage.yaml
@@ -4,7 +4,7 @@ metadata:
   name: storage
   namespace: buildbarn
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       app: storage
@@ -16,15 +16,19 @@ spec:
     spec:
       containers:
       - args:
-        - /config/storage.json
-        image: buildbarn/bb-storage:20190617T155413Z-3c42fa4
+        - /config/storage.jsonnet
+        image: buildbarn/bb-storage:20200102T100452Z-f920d92
         name: storage
         ports:
-        - containerPort: 8980
+        - containerPort: 8981
           protocol: TCP
         volumeMounts:
-        - mountPath: /config
+        - mountPath: /config/storage.jsonnet
           name: config
+          subPath: storage.jsonnet
+        - mountPath: /config/common.libsonnet
+          name: common
+          subPath: common.libsonnet
         - mountPath: /cas
           name: cas
         - mountPath: /ac
@@ -33,6 +37,9 @@ spec:
       - configMap:
           name: storage
         name: config
+      - configMap:
+          name: common
+        name: common
   volumeClaimTemplates:
   - metadata:
       name: cas
@@ -62,7 +69,8 @@ metadata:
 spec:
   clusterIP: None
   ports:
-  - port: 8980
+  - port: 8981
     protocol: TCP
+    name: grpc
   selector:
     app: storage

--- a/kubernetes/storage.yaml
+++ b/kubernetes/storage.yaml
@@ -23,23 +23,27 @@ spec:
         - containerPort: 8981
           protocol: TCP
         volumeMounts:
-        - mountPath: /config/storage.jsonnet
-          name: config
-          subPath: storage.jsonnet
-        - mountPath: /config/common.libsonnet
-          name: common
-          subPath: common.libsonnet
+        - mountPath: /config/
+          name: configs
+          readOnly: true
         - mountPath: /cas
           name: cas
         - mountPath: /ac
           name: ac
       volumes:
-      - configMap:
-          name: storage
-        name: config
-      - configMap:
-          name: common
-        name: common
+      - name: configs
+        projected:
+          sources:
+          - configMap:
+              name: storage
+              items:
+              - key: storage.jsonnet
+                path: storage.jsonnet
+          - configMap:
+              name: common
+              items:
+              - key: common.libsonnet
+                path: common.libsonnet
   volumeClaimTemplates:
   - metadata:
       name: cas

--- a/kubernetes/worker-ubuntu16-04.yaml
+++ b/kubernetes/worker-ubuntu16-04.yaml
@@ -24,12 +24,9 @@ spec:
         image: buildbarn/bb-worker:20200102T102244Z-300a067
         name: worker
         volumeMounts:
-        - mountPath: /config/worker-ubuntu16-04.jsonnet
-          name: worker-config
-          subPath: worker-ubuntu16-04.jsonnet
-        - mountPath: /config/common.libsonnet
-          name: common
-          subPath: common.libsonnet
+        - mountPath: /config/
+          name: configs
+          readOnly: true
         - mountPath: /worker
           name: worker
         env:
@@ -46,12 +43,9 @@ spec:
         image: buildbarn/bb-runner-ubuntu16-04:20200102T102244Z-300a067
         name: runner
         volumeMounts:
-        - mountPath: /config/runner-ubuntu16-04.jsonnet
-          name: runner-config
-          subPath: runner-ubuntu16-04.jsonnet
-        - mountPath: /config/common.libsonnet
-          name: common
-          subPath: common.libsonnet
+        - mountPath: /config/
+          name: configs
+          readOnly: true
         - mountPath: /worker
           name: worker
       initContainers:
@@ -65,14 +59,23 @@ spec:
         - mountPath: /worker
           name: worker
       volumes:
-      - configMap:
-          name: worker-ubuntu16-04
-        name: worker-config
-      - configMap:
-          name: runner-ubuntu16-04
-        name: runner-config
-      - configMap:
-          name: common
-        name: common
+      - name: configs
+        projected:
+          sources:
+          - configMap:
+              name: runner-ubuntu16-04
+              items:
+              - key: runner-ubuntu16-04.jsonnet
+                path: runner-ubuntu16-04.jsonnet
+          - configMap:
+              name: worker-ubuntu16-04
+              items:
+              - key: worker-ubuntu16-04.jsonnet
+                path: worker-ubuntu16-04.jsonnet
+          - configMap:
+              name: common
+              items:
+              - key: common.libsonnet
+                path: common.libsonnet
       - emptyDir: {}
         name: worker

--- a/kubernetes/worker-ubuntu16-04.yaml
+++ b/kubernetes/worker-ubuntu16-04.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: worker-ubuntu16-04
   namespace: buildbarn
+  annotations:
+    prometheus.io/port: "80"
+    prometheus.io/scrape: "true"
 spec:
   replicas: 8
   selector:
@@ -11,30 +14,44 @@ spec:
       instance: ubuntu16-04
   template:
     metadata:
-      annotations:
-        prometheus.io/port: "80"
-        prometheus.io/scrape: "true"
       labels:
         app: worker
         instance: ubuntu16-04
     spec:
       containers:
       - args:
-        - /config/worker.json
-        image: buildbarn/bb-worker:20190617T153934Z-810b6b8
+        - /config/worker-ubuntu16-04.jsonnet
+        image: buildbarn/bb-worker:20200102T102244Z-300a067
         name: worker
         volumeMounts:
-        - mountPath: /config
+        - mountPath: /config/worker-ubuntu16-04.jsonnet
           name: worker-config
+          subPath: worker-ubuntu16-04.jsonnet
+        - mountPath: /config/common.libsonnet
+          name: common
+          subPath: common.libsonnet
         - mountPath: /worker
           name: worker
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
       - args:
-        - /config/runner.json
-        image: buildbarn/bb-runner-ubuntu16-04:20190617T153934Z-810b6b8
+        - /config/runner-ubuntu16-04.jsonnet
+        image: buildbarn/bb-runner-ubuntu16-04:20200102T102244Z-300a067
         name: runner
         volumeMounts:
-        - mountPath: /config
+        - mountPath: /config/runner-ubuntu16-04.jsonnet
           name: runner-config
+          subPath: runner-ubuntu16-04.jsonnet
+        - mountPath: /config/common.libsonnet
+          name: common
+          subPath: common.libsonnet
         - mountPath: /worker
           name: worker
       initContainers:
@@ -52,7 +69,10 @@ spec:
           name: worker-ubuntu16-04
         name: worker-config
       - configMap:
-          name: runner
+          name: runner-ubuntu16-04
         name: runner-config
+      - configMap:
+          name: common
+        name: common
       - emptyDir: {}
         name: worker

--- a/kubernetes/worker-ubuntu16-04.yaml
+++ b/kubernetes/worker-ubuntu16-04.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: worker-ubuntu16-04


### PR DESCRIPTION
This PR updates the kubernetes deployment to work with the latest changes throughout the buildbarn services.

Note: All HTTP endpoints are 7980.

 Prometheus Annotations are removed as these have no effect on services and seemed out of place only on the worker.

Prometheus Service Monitors can instead be configured to scrape all services matching a given criteria.

Addresses #10