### PR TITLE
Use bb-runner-installer in the kubernetes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "04b10647f76983c9fb4cc8d6eb763ec90107882818a9c6bef70bdadb0fdf8df9",
-    strip_prefix = "bazel-toolchains-1.2.4",
+    sha256 = "144290c4166bd67e76a54f96cd504ed86416ca3ca82030282760f0823c10be48",
+    strip_prefix = "bazel-toolchains-3.1.1",
     urls = [
-        "https://github.com/bazelbuild/bazel-toolchains/releases/download/1.2.4/bazel-toolchains-1.2.4.tar.gz",
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/1.2.4.tar.gz",
+        "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.1.1/bazel-toolchains-3.1.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/releases/download/3.1.1/bazel-toolchains-3.1.1.tar.gz",
     ],
 )
 

--- a/kubernetes/browser.yaml
+++ b/kubernetes/browser.yaml
@@ -14,7 +14,7 @@ spec:
         app: browser
     spec:
       containers:
-      - image: buildbarn/bb-browser:20200102T103638Z-e432c91
+      - image: buildbarn/bb-browser:20200511T201709Z-7e80ec0
         args:
         - /config/browser.jsonnet
         name: browser

--- a/kubernetes/config/common.yaml
+++ b/kubernetes/config/common.yaml
@@ -19,18 +19,20 @@ data:
           },
         },
         actionCache: {
-          sharding: {
-            hashInitialization: 14897363947481274433,
-            shards: [
-              {
-                backend: { grpc: { address: 'storage-0.storage.buildbarn:8981' } },
-                weight: 1,
-              },
-              {
-                backend: { grpc: { address: 'storage-1.storage.buildbarn:8981' } },
-                weight: 1,
-              },
-            ],
+          completenessChecking: {
+            sharding: {
+              hashInitialization: 14897363947481274433,
+              shards: [
+                {
+                  backend: { grpc: { address: 'storage-0.storage.buildbarn:8981' } },
+                  weight: 1,
+                },
+                {
+                  backend: { grpc: { address: 'storage-1.storage.buildbarn:8981' } },
+                  weight: 1,
+                },
+              ],
+            },
           },
         },
       },

--- a/kubernetes/config/frontend.yaml
+++ b/kubernetes/config/frontend.yaml
@@ -13,7 +13,7 @@ data:
       schedulers: {
         'remote-execution': { address: 'scheduler:8982' },
       },
-      verifyActionResultCompleteness: true,
+
       maximumMessageSizeBytes: common.maximumMessageSizeBytes,
     }
 kind: ConfigMap

--- a/kubernetes/config/scheduler.yaml
+++ b/kubernetes/config/scheduler.yaml
@@ -13,7 +13,8 @@ data:
         listenAddresses: [':8983'],
         authenticationPolicy: { allow: {} },
       }],
-      blobstore: common.blobstore,
+      contentAddressableStorage: common.blobstore.contentAddressableStorage,
+      maximumMessageSizeBytes: common.maximumMessageSizeBytes,
     }
 kind: ConfigMap
 metadata:

--- a/kubernetes/config/worker-ubuntu16-04.yaml
+++ b/kubernetes/config/worker-ubuntu16-04.yaml
@@ -23,7 +23,7 @@ data:
         platform: {
           properties: [
             { name: 'OSFamily', value: 'Linux' },
-            { name: 'container-image', value: 'docker://marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:6ad1d0883742bfd30eba81e292c135b95067a6706f3587498374a083b7073cb9' },
+            { name: 'container-image', value: 'docker://marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:b516a2d69537cb40a7c6a7d92d0008abb29fba8725243772bdaf2c83f1be2272' },
           ],
         },
         defaultExecutionTimeout: '1800s',

--- a/kubernetes/frontend.yaml
+++ b/kubernetes/frontend.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
       - args:
         - /config/frontend.jsonnet
-        image: buildbarn/bb-storage:20200102T100452Z-f920d92
+        image: buildbarn/bb-storage:20200505T185354Z-e1deeaf
         name: storage
         ports:
         - containerPort: 8980

--- a/kubernetes/run.sh
+++ b/kubernetes/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-kubectl create -f bb-namespace.yaml
+kubectl apply -f bb-namespace.yaml
 for file in config/*.yaml; do
-  kubectl create -f $file
+  kubectl apply -f $file
 done
 for file in *.yaml; do
-  kubectl create -f $file
+  kubectl apply -f $file
 done

--- a/kubernetes/scheduler.yaml
+++ b/kubernetes/scheduler.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - args:
         - /config/scheduler.jsonnet
-        image: buildbarn/bb-scheduler:20200102T102244Z-300a067
+        image: buildbarn/bb-scheduler:20200511T200952Z-aebf2a6
         name: scheduler
         ports:
         - containerPort: 8982

--- a/kubernetes/storage.yaml
+++ b/kubernetes/storage.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - args:
         - /config/storage.jsonnet
-        image: buildbarn/bb-storage:20200102T100452Z-f920d92
+        image: buildbarn/bb-storage:20200505T185354Z-e1deeaf
         name: storage
         ports:
         - containerPort: 8981

--- a/kubernetes/worker-ubuntu16-04.yaml
+++ b/kubernetes/worker-ubuntu16-04.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - args:
         - /config/worker-ubuntu16-04.jsonnet
-        image: buildbarn/bb-worker:20200102T102244Z-300a067
+        image: buildbarn/bb-worker:20200511T200952Z-aebf2a6
         name: worker
         volumeMounts:
         - mountPath: /config/
@@ -41,6 +41,9 @@ spec:
       - command: [/bb/tini, -v, -g, --, /bb/bb_runner, /config/runner-ubuntu16-04.jsonnet]
         image: marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:b516a2d69537cb40a7c6a7d92d0008abb29fba8725243772bdaf2c83f1be2272
         name: runner
+        securityContext:
+          runAsUser: 65534
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /config/
           name: configs
@@ -52,7 +55,7 @@ spec:
           readOnly: true
       initContainers:
       - name: bb-runner-installer
-        image: buildbarn/bb-runner-installer:20200102T102244Z-300a067
+        image: buildbarn/bb-runner-installer:20200511T200952Z-aebf2a6
         volumeMounts:
         - mountPath: /bb/
           name: bb-runner

--- a/kubernetes/worker-ubuntu16-04.yaml
+++ b/kubernetes/worker-ubuntu16-04.yaml
@@ -38,9 +38,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-      - args:
-        - /config/runner-ubuntu16-04.jsonnet
-        image: buildbarn/bb-runner-ubuntu16-04:20200102T102244Z-300a067
+      - command: [/bb/tini, -v, -g, --, /bb/bb_runner, /config/runner-ubuntu16-04.jsonnet]
+        image: marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:b516a2d69537cb40a7c6a7d92d0008abb29fba8725243772bdaf2c83f1be2272
         name: runner
         volumeMounts:
         - mountPath: /config/
@@ -48,9 +47,17 @@ spec:
           readOnly: true
         - mountPath: /worker
           name: worker
+        - mountPath: /bb
+          name: bb-runner
+          readOnly: true
       initContainers:
+      - name: bb-runner-installer
+        image: buildbarn/bb-runner-installer:20200102T102244Z-300a067
+        volumeMounts:
+        - mountPath: /bb/
+          name: bb-runner
       - name: volume-init
-        image: busybox:1.30.1
+        image: busybox:1.31.1-uclibc
         command:
         - sh
         - -c
@@ -59,6 +66,8 @@ spec:
         - mountPath: /worker
           name: worker
       volumes:
+      - name: bb-runner
+        emptyDir: {}
       - name: configs
         projected:
           sources:


### PR DESCRIPTION
This arrangement allows arbitrary versions of the
google/rbe-ubuntu16-04 image to be selected, instead of being pinned
to one in a particular buildbarn version.