### PR TITLE
use volumes for all storage plus depends_on

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -91,7 +91,7 @@ services:
     - ./config:/config
     depends_on:
     - runner-installer
- 
+
   runner-installer:
     image: buildbarn/bb-runner-installer:20200528T061211Z-4dfbe5b
     volumes:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.7'
 services:
   frontend:
     image: buildbarn/bb-storage:20200520T103928Z-32c5ba0
@@ -20,8 +20,8 @@ services:
     - 7981:7981
     volumes:
     - ./config:/config
-    - ./storage-ac-0:/storage-ac
-    - ./storage-cas-0:/storage-cas
+    - storage-ac-0:/storage-ac
+    - storage-cas-0:/storage-cas
 
   storage-1:
     image: buildbarn/bb-storage:20200520T103928Z-32c5ba0
@@ -33,8 +33,8 @@ services:
     - 17981:7981
     volumes:
     - ./config:/config
-    - ./storage-ac-1:/storage-ac
-    - ./storage-cas-1:/storage-cas
+    - storage-ac-1:/storage-ac
+    - storage-cas-1:/storage-cas
 
   scheduler:
     image: buildbarn/bb-scheduler:20200528T061211Z-4dfbe5b
@@ -47,6 +47,9 @@ services:
     - 7982:7982
     volumes:
     - ./config:/config
+    depends_on:
+    - storage-0
+    - storage-1
 
   browser:
     image: buildbarn/bb-browser:20200514T172056Z-1c2932b
@@ -56,6 +59,9 @@ services:
     - 7984:7984
     volumes:
     - ./config:/config
+    depends_on:
+    - storage-0
+    - storage-1
 
   worker-ubuntu16-04:
     image: buildbarn/bb-worker:20200528T061211Z-4dfbe5b
@@ -65,7 +71,12 @@ services:
     - 7986:7986
     volumes:
     - ./config:/config
-    - ./worker-ubuntu16-04:/worker
+    - buildbarn-worker-ubuntu16-04:/worker
+    depends_on:
+    - storage-0
+    - storage-1
+    - scheduler
+    - runner-ubuntu16-04
 
   runner-ubuntu16-04:
     image: l.gcr.io/google/rbe-ubuntu16-04@sha256:b516a2d69537cb40a7c6a7d92d0008abb29fba8725243772bdaf2c83f1be2272
@@ -75,13 +86,23 @@ services:
     - while ! test -f /bb/installed; do sleep 1; done; exec /bb/tini -v -g -- /bb/bb_runner /config/runner-ubuntu16-04.jsonnet
     network_mode: none
     volumes:
-    - ./worker-ubuntu16-04:/worker
+    - buildbarn-worker-ubuntu16-04:/worker
+    - buildbarn-tini:/bb
     - ./config:/config
-    - ./bb:/bb
     depends_on:
     - runner-installer
-
+ 
   runner-installer:
     image: buildbarn/bb-runner-installer:20200528T061211Z-4dfbe5b
     volumes:
-    - ./bb:/bb
+    - buildbarn-tini:/bb
+
+volumes:
+  buildbarn-worker-ubuntu16-04:
+    external: true
+  storage-ac-0:
+  storage-ac-1:
+  storage-cas-0:
+  storage-cas-1:
+  buildbarn-tini:
+    external: true

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3'
 services:
   frontend:
     image: buildbarn/bb-storage:20200520T103928Z-32c5ba0

--- a/docker-compose/run.sh
+++ b/docker-compose/run.sh
@@ -9,8 +9,6 @@ docker volume rm "${worker_volume}" || true
 docker volume rm "${tini_volume}" || true
 
 docker volume create "${worker_volume}"
-docker volume create "${tini_volume}"
-
 docker run --rm \
   -v "${worker_volume}:/worker" \
   busybox:latest \

--- a/docker-compose/run.sh
+++ b/docker-compose/run.sh
@@ -2,10 +2,18 @@
 
 set -eux
 
-worker="worker-ubuntu16-04"
+worker_volume="buildbarn-worker-ubuntu16-04"
+tini_volume="buildbarn-tini"
 
-sudo rm -rf bb "${worker}"
-mkdir -m 0777 "${worker}" "${worker}/build"
-mkdir -m 0700 "${worker}/cache"
+docker volume rm "${worker_volume}" || true
+docker volume rm "${tini_volume}" || true
+
+docker volume create "${worker_volume}"
+docker volume create "${tini_volume}"
+
+docker run --rm \
+  -v "${worker_volume}:/worker" \
+  busybox:latest \
+  /bin/sh -c 'mkdir -p /worker/build /worker/cache'
 
 exec docker-compose up


### PR DESCRIPTION
Changes:

- Use volumes for all storage. Removes need to `sudo`. (`run.sh` uses a busybox container to do the `mkdir`'s in the worker's volume). Also, my source trees are mounted into a Linux VM via VirtualBox shared folders and this avoids needing to put the CAS storage on that mount point.

- Also added a more comprehensive set of `depends_on` annotations. 