### PR TITLE
some fixes for the new bare config example

### DIFF
--- a/bare/README.md
+++ b/bare/README.md
@@ -24,7 +24,7 @@ the following options should be added to `~/.bazelrc`:
 ```
 build:local --config=rbe-ubuntu16-04
 build:local --jobs=8
-build:local --remote_executor=localhost:8980
+build:local --remote_executor=grpc://localhost:8980
 build:local --remote_instance_name=local
 ```
 


### PR DESCRIPTION
Here are a few proposed fixes for the bare example. It still doesn't quite work for me yet, I'm getting the following error:

```
ERROR: /home/user/.cache/bazel/_bazel_user/5dc217035a371a2209c1f6921a765276/external/zlib/BUILD.bazel:31:11 Executing genrule @zlib//:copy_public_headers failed (Exit 34). Note: Remote connection/protocol failed with: execution failed FAILED_PRECONDITION: No workers exist for instance "local" platform {"properties":[{"name":"OSFamily","value":"Linux"},{"name":"container-image","value":"docker://marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:b516a2d69537cb40a7c6a7d92d0008abb29fba8725243772bdaf2c83f1be2272"}]}
```