### PR TITLE
Remove broken reference to the remote config in the bare example

### DIFF
--- a/bare/README.md
+++ b/bare/README.md
@@ -22,7 +22,6 @@ In addition to [the generic build options](https://github.com/buildbarn/bb-deplo
 the following options should be added to `~/.bazelrc`:
 
 ```
-build:local --config=remote
 build:local --jobs=8
 build:local --remote_executor=grpc://localhost:8980
 build:local --remote_instance_name=local


### PR DESCRIPTION
The remote config was removed previously, because bazel can figure this out itself:
https://github.com/buildbarn/bb-deployments/commit/6bae7658de44b82bec2bc4d329351f15ced49f91

This fixes the following error:

ERROR: Config value remote is not defined in any .rc file