### PR TITLE
Bare startup logging

### DIFF
--- a/bare/main.go
+++ b/bare/main.go
@@ -44,6 +44,7 @@ func main() {
 		{config: "bare/config/browser.jsonnet", binary: "bb_browser"},
 	}
 	for _, bb := range bbs {
+		log.Println("Starting", bb.binary)
 		go bbStart(bb)
 	}
 

--- a/bare/main.go
+++ b/bare/main.go
@@ -35,6 +35,9 @@ func main() {
 	os.Mkdir("storage-ac", 0755)
 	os.Mkdir("storage-cas", 0755)
 
+	log.Println("Don't worry if you see some \"Failed to synchronize with scheduler\" warnings on startup")
+	log.Println("\t- they should stop once bb_scheduler is ready")
+
 	bbs := []buildbarnProcess{
 		{config: "bare/config/storage.jsonnet", binary: "bb_storage"},
 		{config: "bare/config/frontend.jsonnet", binary: "bb_storage"},


### PR DESCRIPTION
These two commits make the bare example startup a little more understandable. The logs look something like this:
```
2020/06/12 09:25:34 Starting bb_storage
2020/06/12 09:25:34 Starting bb_storage
2020/06/12 09:25:34 Starting bb_scheduler
2020/06/12 09:25:34 Sleeping 1s to allow bb_scheduler to start
2020/06/12 09:25:35 Starting bb_worker
2020/06/12 09:25:35 Starting bb_runner
2020/06/12 09:25:35 Starting bb_browser
```