### PR TITLE
Set browserUrl in kubernetes worker

### DIFF
--- a/kubernetes/config/worker-ubuntu16-04.yaml
+++ b/kubernetes/config/worker-ubuntu16-04.yaml
@@ -10,6 +10,7 @@ data:
       httpListenAddress: common.httpListenAddress,
       maximumMemoryCachedDirectories: 1000,
       instanceName: 'remote-execution',
+      browserUrl: common.browserUrl,
       buildDirectories: [{
         native: {
           buildDirectoryPath: '/worker/build',


### PR DESCRIPTION
Without this change errors returned by worker and displayed in bazel client do not have domain, like:

  `Action details (cached result): /action/ubuntu16-04/<sha>/141/`

After this change:

  `Action details (cached result): <browserUrl>/action/ubuntu16-04/<sha>/141/`

Noticed in bazel 3.2 and standard bb docker images.