### PR TITLE
Set browserUrl in kubernetes scheduler template

### DIFF
--- a/kubernetes/config/scheduler.yaml
+++ b/kubernetes/config/scheduler.yaml
@@ -15,6 +15,7 @@ data:
       }],
       contentAddressableStorage: common.blobstore.contentAddressableStorage,
       maximumMessageSizeBytes: common.maximumMessageSizeBytes,
+      browserUrl: common.browserUrl,
     }
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
It assures links on scheduler status page work as expected.