### PR TITLE
Update docs to ensure runner containers SHA match

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ This is usually because container of the worker has started before the scheduler
 
 Bazel can perform remote builds against these deployments by adding [the official Bazel toolchain definitions](https://releases.bazel.build/bazel-toolchains.html) for the RBE container images to the `WORKSPACE` file of your project. It is also possible to derive your own configuration files using the `rbe_autoconfig`. More information can be found by reading the documentation [here](https://github.com/bazelbuild/bazel-toolchains/blob/master/rules/rbe_repo.bzl).
 
+After installing the bazel_toolchains repository in your `WORKSPACE`, ensure that the Worker & Runner configuration for the "worker-ubuntu16-04" image SHA matches the version that is expected from the toolchain version. Note: this SHA is must match both in the jsonnet configuration and the configuration used to pull and run the actual container (docker compose, kubernetes yaml, etc...)
+
+```shell
+cat $(bazel info output_base)/external/bazel_toolchains/configs/dependency-tracking/ubuntu1604.bzl
+```
+
 For this example, we have provided the necessary `WORKSPACE` setup already but we still need to create the `.bazelrc`. In a separate terminal to your docker-compose deployment, create your `.bazelrc` in the project root:
 ```
 cd bb-deployments/


### PR DESCRIPTION
Helpful hint in documentation for #17 

I was just bitten by this one. The error message contains the configuration that matches exactly aside from the SHA, which makes it difficult to notice. I do think that BB should probably stay on top of the SHA with whatever is latest in build_toolchains. 