### PR TITLE
Update docker-compose configurations

### DIFF
--- a/docker-compose/config/browser.jsonnet
+++ b/docker-compose/config/browser.jsonnet
@@ -4,4 +4,5 @@ local common = import 'common.libsonnet';
   blobstore: common.blobstore,
   maximumMessageSizeBytes: common.maximumMessageSizeBytes,
   listenAddress: ':7984',
+  global: common.global,
 }

--- a/docker-compose/config/common.libsonnet
+++ b/docker-compose/config/common.libsonnet
@@ -36,4 +36,5 @@
   browserUrl: 'http://localhost:7984',
   httpListenAddress: ':80',
   maximumMessageSizeBytes: 16 * 1024 * 1024,
+  global: { diagnosticsHttpListenAddress: ':9980' },
 }

--- a/docker-compose/config/frontend.jsonnet
+++ b/docker-compose/config/frontend.jsonnet
@@ -2,7 +2,7 @@ local common = import 'common.libsonnet';
 
 {
   blobstore: common.blobstore,
-  httpListenAddress: ':7980',
+  global: common.global,
   grpcServers: [{
     listenAddresses: [':8980'],
     authenticationPolicy: { allow: {} },

--- a/docker-compose/config/runner-ubuntu16-04.jsonnet
+++ b/docker-compose/config/runner-ubuntu16-04.jsonnet
@@ -1,5 +1,8 @@
+local common = import 'common.libsonnet';
+
 {
   buildDirectoryPath: '/worker/build',
+  global: common.global,
   grpcServers: [{
     listenPaths: ['/worker/runner'],
     authenticationPolicy: { allow: {} },

--- a/docker-compose/config/scheduler.jsonnet
+++ b/docker-compose/config/scheduler.jsonnet
@@ -1,7 +1,7 @@
 local common = import 'common.libsonnet';
 
 {
-  httpListenAddress: ':7982',
+  adminHttpListenAddress: ':7982',
   clientGrpcServers: [{
     listenAddresses: [':8982'],
     authenticationPolicy: { allow: {} },
@@ -10,6 +10,7 @@ local common = import 'common.libsonnet';
     listenAddresses: [':8983'],
     authenticationPolicy: { allow: {} },
   }],
+  global: common.global,
   browserUrl: common.browserUrl,
   contentAddressableStorage: common.blobstore.contentAddressableStorage,
   maximumMessageSizeBytes: common.maximumMessageSizeBytes,

--- a/docker-compose/config/storage.jsonnet
+++ b/docker-compose/config/storage.jsonnet
@@ -3,26 +3,63 @@ local common = import 'common.libsonnet';
 {
   blobstore: {
     contentAddressableStorage: {
-      circular: {
-        directory: '/storage-cas',
-        offsetFileSizeBytes: 16 * 1024 * 1024,
-        offsetCacheSize: 10000,
-        dataFileSizeBytes: 10 * 1024 * 1024 * 1024,
-        dataAllocationChunkSizeBytes: 16 * 1024 * 1024,
+      'local': {
+        keyLocationMapOnBlockDevice: {
+          file: {
+            path: '/storage-cas/key_location_map',
+            sizeBytes: 100 * 1024 * 1024,
+          },
+        },
+        keyLocationMapMaximumGetAttempts: 8,
+        keyLocationMapMaximumPutAttempts: 32,
+        oldBlocks: 8,
+        currentBlocks: 24,
+        newBlocks: 3,
+        blocksOnBlockDevice: {
+          source: {
+            file: {
+              path: '/storage-cas/blocks',
+              sizeBytes: 2 * 1024 * 1024 * 1024,
+            },
+          },
+          spareBlocks: 3,
+        },
+        persistent: {
+          stateDirectoryPath: '/storage-cas/persistent_state',
+          minimumEpochInterval: '5m',
+        },
       },
     },
     actionCache: {
-      circular: {
-        directory: '/storage-ac',
-        offsetFileSizeBytes: 1024 * 1024,
-        offsetCacheSize: 1000,
-        dataFileSizeBytes: 100 * 1024 * 1024,
-        dataAllocationChunkSizeBytes: 1048576,
-        instances: ['bb-event-service', 'remote-execution'],
+      'local': {
+        keyLocationMapOnBlockDevice: {
+          file: {
+            path: '/storage-ac/key_location_map',
+            sizeBytes: 1024 * 1024,
+          },
+        },
+        keyLocationMapMaximumGetAttempts: 8,
+        keyLocationMapMaximumPutAttempts: 32,
+        oldBlocks: 8,
+        currentBlocks: 24,
+        newBlocks: 3,
+        blocksOnBlockDevice: {
+          source: {
+            file: {
+              path: '/storage-ac/blocks',
+              sizeBytes: 20 * 1024 * 1024,
+            },
+          },
+          spareBlocks: 3,
+        },
+        persistent: {
+          stateDirectoryPath: '/storage-ac/persistent_state',
+          minimumEpochInterval: '5m',
+        },
       },
     },
   },
-  httpListenAddress: ':7981',
+  global: common.global,
   grpcServers: [{
     listenAddresses: [':8981'],
     authenticationPolicy: { allow: {} },

--- a/docker-compose/config/worker-ubuntu16-04.jsonnet
+++ b/docker-compose/config/worker-ubuntu16-04.jsonnet
@@ -4,7 +4,7 @@ local common = import 'common.libsonnet';
   blobstore: common.blobstore,
   maximumMessageSizeBytes: common.maximumMessageSizeBytes,
   scheduler: { address: 'scheduler:8983' },
-  httpListenAddress: ':7986',
+  global: common.global,
   maximumMemoryCachedDirectories: 1000,
   instanceName: 'remote-execution',
   buildDirectories: [{
@@ -20,9 +20,9 @@ local common = import 'common.libsonnet';
       concurrency: 8,
       platform: {
         properties: [
-          { name: 'OSFamily', value: 'Linux' },
-          { name: 'container-image', value: 'docker://marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:b516a2d69537cb40a7c6a7d92d0008abb29fba8725243772bdaf2c83f1be2272' },
-        ],
+          { name: "OSFamily", value: "Linux" },
+          { name: "container-image", value: "docker://marketplace.gcr.io/google/rbe-ubuntu16-04@sha256:f6568d8168b14aafd1b707019927a63c2d37113a03bcee188218f99bd0327ea1"}
+        ]
       },
       defaultExecutionTimeout: '1800s',
       maximumExecutionTimeout: '3600s',

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,9 +1,11 @@
 version: '3'
 services:
   frontend:
-    image: buildbarn/bb-storage:20200904T173922Z-e3f0e59
+    image: buildbarn/bb-storage:20201219T141331Z-3d6325d
     command:
     - /config/frontend.jsonnet
+    expose:
+    - 9980
     ports:
     - 7980:7980
     - 8980:8980
@@ -11,11 +13,12 @@ services:
     - ./config:/config
 
   storage-0:
-    image: buildbarn/bb-storage:20200904T173922Z-e3f0e59
+    image: buildbarn/bb-storage:20201219T141331Z-3d6325d
     command:
     - /config/storage.jsonnet
     expose:
     - 8981
+    - 9980
     ports:
     - 7981:7981
     volumes:
@@ -24,11 +27,12 @@ services:
     - ./storage-cas-0:/storage-cas
 
   storage-1:
-    image: buildbarn/bb-storage:20200904T173922Z-e3f0e59
+    image: buildbarn/bb-storage:20201219T141331Z-3d6325d
     command:
     - /config/storage.jsonnet
     expose:
     - 8981
+    - 9980
     ports:
     - 17981:7981
     volumes:
@@ -37,28 +41,31 @@ services:
     - ./storage-cas-1:/storage-cas
 
   scheduler:
-    image: buildbarn/bb-scheduler:20200904T190834Z-91bd2dc
+    image: buildbarn/bb-scheduler:20201218T103144Z-6f7de1f
     command:
     - /config/scheduler.jsonnet
     expose:
     - 8982
     - 8983
+    - 9980
     ports:
     - 7982:7982
     volumes:
     - ./config:/config
 
   browser:
-    image: buildbarn/bb-browser:20200816T120922Z-6dc5c54
+    image: buildbarn/bb-browser:20201221T062016Z-d21170a
     command:
     - /config/browser.jsonnet
+    expose:
+    - 9980
     ports:
     - 7984:7984
     volumes:
     - ./config:/config
 
   worker-ubuntu16-04:
-    image: buildbarn/bb-worker:20200904T190834Z-91bd2dc
+    image: buildbarn/bb-worker:20201218T103144Z-6f7de1f
     command:
     - /config/worker-ubuntu16-04.jsonnet
     ports:
@@ -82,6 +89,6 @@ services:
     - runner-installer
 
   runner-installer:
-    image: buildbarn/bb-runner-installer:20200904T190834Z-91bd2dc
+    image: buildbarn/bb-runner-installer:20201218T103144Z-6f7de1f
     volumes:
     - ./bb:/bb


### PR DESCRIPTION
I was able to get this configuration working and tested with bazel 3.3.1 and bazelrc options from [bazel-2.0.0.bazelrc](https://github.com/bazelbuild/bazel-toolchains/blob/master/bazelrc/bazel-2.0.0.bazelrc).

Circular blob stores are replaced with some LocalBlobAccess replacements and port 9980 is exposed for diagnostics.