### PR TITLE
Add missing completenessChecking to bare deployment

### DIFF
--- a/bare/config/common.libsonnet
+++ b/bare/config/common.libsonnet
@@ -15,8 +15,10 @@
       },
     },
     actionCache: {
-      grpc: {
-        address: 'localhost:8981',
+      completenessChecking: {
+        grpc: {
+          address: 'localhost:8981',
+        },
       },
     },
   },


### PR DESCRIPTION
Without completeness checking of the action cache, Buildbarn may return action results where outputs are missing from the CAS. This is against the RE API and, for example, makes Bazel crash.