### PR TITLE
Increase default CAS size from 8 to 32 GiB

### DIFF
--- a/bare/config/storage.jsonnet
+++ b/bare/config/storage.jsonnet
@@ -13,7 +13,7 @@ local common = import 'common.libsonnet';
         keyLocationMapOnBlockDevice: {
           file: {
             path: 'storage-cas/key_location_map',
-            sizeBytes: 100 * 1024 * 1024,
+            sizeBytes: 400 * 1024 * 1024,
           },
         },
         keyLocationMapMaximumGetAttempts: 8,
@@ -25,7 +25,7 @@ local common = import 'common.libsonnet';
           source: {
             file: {
               path: 'storage-cas/blocks',
-              sizeBytes: 8 * 1024 * 1024 * 1024,
+              sizeBytes: 32 * 1024 * 1024 * 1024,
             },
           },
           spareBlocks: 3,

--- a/docker-compose/config/storage.jsonnet
+++ b/docker-compose/config/storage.jsonnet
@@ -13,7 +13,7 @@ local common = import 'common.libsonnet';
         keyLocationMapOnBlockDevice: {
           file: {
             path: '/storage-cas/key_location_map',
-            sizeBytes: 100 * 1024 * 1024,
+            sizeBytes: 400 * 1024 * 1024,
           },
         },
         keyLocationMapMaximumGetAttempts: 8,
@@ -25,7 +25,7 @@ local common = import 'common.libsonnet';
           source: {
             file: {
               path: '/storage-cas/blocks',
-              sizeBytes: 8 * 1024 * 1024 * 1024,
+              sizeBytes: 32 * 1024 * 1024 * 1024,
             },
           },
           spareBlocks: 3,

--- a/docker-compose/config/worker-fuse-ubuntu22-04.jsonnet
+++ b/docker-compose/config/worker-fuse-ubuntu22-04.jsonnet
@@ -13,7 +13,7 @@ local common = import 'common.libsonnet';
             keyLocationMapOnBlockDevice: {
               file: {
                 path: '/worker/cas/key_location_map',
-                sizeBytes: 100 * 1024 * 1024,
+                sizeBytes: 400 * 1024 * 1024,
               },
             },
             keyLocationMapMaximumGetAttempts: 8,
@@ -25,7 +25,7 @@ local common = import 'common.libsonnet';
               source: {
                 file: {
                   path: '/worker/cas/blocks',
-                  sizeBytes: 8 * 1024 * 1024 * 1024,
+                  sizeBytes: 32 * 1024 * 1024 * 1024,
                 },
               },
               spareBlocks: 3,

--- a/kubernetes/config/storage.yaml
+++ b/kubernetes/config/storage.yaml
@@ -16,7 +16,7 @@ data:
             keyLocationMapOnBlockDevice: {
               file: {
                 path: '/storage-cas/key_location_map',
-                sizeBytes: 100 * 1024 * 1024,
+                sizeBytes: 400 * 1024 * 1024,
               },
             },
             keyLocationMapMaximumGetAttempts: 8,
@@ -28,7 +28,7 @@ data:
               source: {
                 file: {
                   path: '/storage-cas/blocks',
-                  sizeBytes: 8 * 1024 * 1024 * 1024,
+                  sizeBytes: 32 * 1024 * 1024 * 1024,
                 },
               },
               spareBlocks: 3,


### PR DESCRIPTION
Too many people gets into problems uploading blobs larger than 8 GiB / 36 blocks = 227 MiB / block, e.g. uploading 282 MiB blobs. Let's just increase the default CAS size 4x.

Fixes #85.