### PR TITLE
docker-compose: Add bb-remote-asset to setup

### DIFF
--- a/docker-compose/config/remote-asset.jsonnet
+++ b/docker-compose/config/remote-asset.jsonnet
@@ -1,0 +1,26 @@
+local common = import 'common.libsonnet';
+{
+  fetcher: {
+    caching: {
+      fetcher: {
+        http: {
+          allowUpdatesForInstances: ['fuse', 'hardlinking'],
+          contentAddressableStorage: common.blobstore.contentAddressableStorage,
+        },
+      },
+    },
+  },
+
+  assetCache: {
+    actionCache: {
+      blobstore: common.blobstore,
+    },
+  },
+  global: common.global,
+  grpcServers: [{
+    listenAddresses: [':8984'],
+    authenticationPolicy: { allow: {} },
+  }],
+  allowUpdatesForInstances: ['foo'],
+  maximumMessageSizeBytes: 16 * 1024 * 1024 * 1024,
+}

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -124,3 +124,15 @@ services:
     - ./volumes/worker-hardlinking-ubuntu22-04:/worker
     depends_on:
     - runner-installer
+
+  remote-asset:
+    # TODO(minor-fixes): Replace with actual container once pushed to ghcr
+    image: bazel/cmd/bb_remote_asset:bb_remote_asset_container
+    command:
+    - /config/remote-asset.jsonnet
+    expose:
+    - 9980
+    ports:
+    - 8984:8984
+    volumes:
+    - ./config:/config


### PR DESCRIPTION
This change adds a bb-remote-asset setup to the docker-compose deployment example, which allows for:

* easier local testing of bb-remote-asset with the other buildbarn components
* a working example of how bb-remote-asset should be configured*

Tested: Started locally via `docker-compose/run.sh`; ran:

```
bazel clean --expunge && \
  rm -rf ~/.cache/bazel/_bazel_$USER/cache/ && \
  bazel build \
    --remote_executor=grpc://localhost:8980 \
    --remote_instance_name=fuse \
    --experimental_remote_downloader=grpc://localhost:8984 \
    //...
```

Build completed successfully, and remote-asset logs showed blobs being downloaded.

Ran the following twice:

```
grpc_cli call localhost:8984 \
  build.bazel.remote.asset.v1.Fetch.FetchBlob \
  'instance_name: "fuse" uris: "https://github.com/bazelbuild/remote-apis/raw/main/build/bazel/remote/asset/v1/remote_asset.proto" qualifiers { name: "checksum.sri" value: "sha256-e8wR0NA0I8XHMeF8Fzk7EjHrLYQp4zUpZtXZIe3c3Fs=" }'
```

and got the following responses:

```
connecting to localhost:8984
status {
  message: "Blob fetched successfully!"
}
uri: "https://github.com/bazelbuild/remote-apis/raw/main/build/bazel/remote/asset/v1/remote_asset.proto"
qualifiers {
  name: "checksum.sri"
  value: "sha256-e8wR0NA0I8XHMeF8Fzk7EjHrLYQp4zUpZtXZIe3c3Fs="
}
blob_digest {
  hash: "7bcc11d0d03423c5c731e17c17393b1231eb2d8429e3352966d5d921eddcdc5b"
  size_bytes: 21947
}
Rpc succeeded with OK status
```

```
connecting to localhost:8984
status {
  message: "Blob fetched successfully from asset cache"
}
uri: "https://github.com/bazelbuild/remote-apis/raw/main/build/bazel/remote/asset/v1/remote_asset.proto"
qualifiers {
  name: "checksum.sri"
  value: "sha256-e8wR0NA0I8XHMeF8Fzk7EjHrLYQp4zUpZtXZIe3c3Fs="
}
blob_digest {
  hash: "7bcc11d0d03423c5c731e17c17393b1231eb2d8429e3352966d5d921eddcdc5b"
  size_bytes: 21947
}
Rpc succeeded with OK status
```

which indicates that caching functionality works as well.

---

*I don't actually know the best way to configure bb-remote-asset