### PR TITLE
Fix OSFamily value capitalization

### DIFF
--- a/docker-compose/config/worker-fuse-ubuntu22-04.jsonnet
+++ b/docker-compose/config/worker-fuse-ubuntu22-04.jsonnet
@@ -69,7 +69,7 @@ local common = import 'common.libsonnet';
       instanceNamePrefix: 'fuse',
       platform: {
         properties: [
-          { name: 'OSFamily', value: 'Linux' },
+          { name: 'OSFamily', value: 'linux' },
           { name: 'container-image', value: 'docker://ghcr.io/catthehacker/ubuntu:act-22.04@sha256:5f9c35c25db1d51a8ddaae5c0ba8d3c163c5e9a4a6cc97acd409ac7eae239448' },
         ],
       },

--- a/docker-compose/config/worker-hardlinking-ubuntu22-04.jsonnet
+++ b/docker-compose/config/worker-hardlinking-ubuntu22-04.jsonnet
@@ -23,7 +23,7 @@ local common = import 'common.libsonnet';
       instanceNamePrefix: 'hardlinking',
       platform: {
         properties: [
-          { name: 'OSFamily', value: 'Linux' },
+          { name: 'OSFamily', value: 'linux' },
           { name: 'container-image', value: 'docker://ghcr.io/catthehacker/ubuntu:act-22.04@sha256:5f9c35c25db1d51a8ddaae5c0ba8d3c163c5e9a4a6cc97acd409ac7eae239448' },
         ],
       },

--- a/kubernetes/config/worker-ubuntu22-04.yaml
+++ b/kubernetes/config/worker-ubuntu22-04.yaml
@@ -24,7 +24,7 @@ data:
           concurrency: 8,
           platform: {
             properties: [
-              { name: 'OSFamily', value: 'Linux' },
+              { name: 'OSFamily', value: 'linux' },
               { name: 'container-image', value: 'docker://ghcr.io/catthehacker/ubuntu:act-22.04@sha256:5f9c35c25db1d51a8ddaae5c0ba8d3c163c5e9a4a6cc97acd409ac7eae239448' },
             ],
           },

--- a/tools/remote-toolchains/BUILD.bazel
+++ b/tools/remote-toolchains/BUILD.bazel
@@ -30,7 +30,7 @@ platform(
     constraint_values = REMOTE_EXEC_CONSTRAINTS,
     exec_properties = {
         "container-image": "docker://ghcr.io/catthehacker/ubuntu:act-22.04@sha256:5f9c35c25db1d51a8ddaae5c0ba8d3c163c5e9a4a6cc97acd409ac7eae239448",
-        "OSFamily": "Linux",
+        "OSFamily": "linux",
     },
 )
 


### PR DESCRIPTION
In accordance with the REv2 API the standard value of the OSFamily platform property should be lowercase.

See
https://github.com/bazelbuild/remote-apis/blob/068363a3625e166056c155f6441cfb35ca8dfbf2/build/bazel/remote/execution/v2/platform.md