### PR TITLE
Reenable the k8s vs docker config diff check

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -36,8 +36,8 @@
                "run": "bazel build //tools/github_workflows && cp bazel-bin/tools/github_workflows/*.yaml .github/workflows"
             },
             {
-               "name": "DISABLED: Check the diff between docker-compose and Kubernetes configs",
-               "run": "true || tools/diff-docker-and-k8s-configs.sh > tools/expected-docker-and-k8s-configs.diff"
+               "name": "Check the diff between docker-compose and Kubernetes configs",
+               "run": "tools/diff-docker-and-k8s-configs.sh > tools/expected-docker-and-k8s-configs.diff"
             },
             {
                "name": "Test style conformance",

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -36,8 +36,8 @@
                "run": "bazel build //tools/github_workflows && cp bazel-bin/tools/github_workflows/*.yaml .github/workflows"
             },
             {
-               "name": "DISABLED: Check the diff between docker-compose and Kubernetes configs",
-               "run": "true || tools/diff-docker-and-k8s-configs.sh > tools/expected-docker-and-k8s-configs.diff"
+               "name": "Check the diff between docker-compose and Kubernetes configs",
+               "run": "tools/diff-docker-and-k8s-configs.sh > tools/expected-docker-and-k8s-configs.diff"
             },
             {
                "name": "Test style conformance",

--- a/tools/diff-docker-and-k8s-configs.sh
+++ b/tools/diff-docker-and-k8s-configs.sh
@@ -15,4 +15,4 @@ diff_config kubernetes/config/frontend.yaml docker-compose/config/frontend.jsonn
 diff_config kubernetes/config/runner-ubuntu22-04.yaml docker-compose/config/runner-ubuntu22-04.jsonnet
 diff_config kubernetes/config/scheduler.yaml docker-compose/config/scheduler.jsonnet
 diff_config kubernetes/config/storage.yaml docker-compose/config/storage.jsonnet
-diff_config kubernetes/config/worker-ubuntu22-04.yaml docker-compose/config/worker-ubuntu22-04.jsonnet
+diff_config kubernetes/config/worker-ubuntu22-04.yaml docker-compose/config/worker-hardlinking-ubuntu22-04.jsonnet

--- a/tools/expected-docker-and-k8s-configs.diff
+++ b/tools/expected-docker-and-k8s-configs.diff
@@ -52,11 +52,18 @@ index 0000000..7f08b6d 100644
    grpcServers: [{
      listenPaths: ['/worker/runner'],
      authenticationPolicy: { allow: {} },
-diff --git a/- b/docker-compose/config/worker-ubuntu22-04.jsonnet
-index 0000000..a9d763d 100644
+diff --git a/- b/docker-compose/config/worker-hardlinking-ubuntu22-04.jsonnet
+index 0000000..3d24b61 100644
 --- a/-
-+++ b/docker-compose/config/worker-ubuntu22-04.jsonnet
-@@ -5,9 +5,7 @@ local common = import 'common.libsonnet';
++++ b/docker-compose/config/worker-hardlinking-ubuntu22-04.jsonnet
+@@ -1,13 +1,14 @@
+ local common = import 'common.libsonnet';
+ 
++// DO NOT USE the hardlinking configuration below unless really needed.
++// This example only exists for reference in situations
++// where the more efficient FUSE worker is not supported.
+ {
+   blobstore: common.blobstore,
    browserUrl: common.browserUrl,
    maximumMessageSizeBytes: common.maximumMessageSizeBytes,
    scheduler: { address: 'scheduler:8983' },
@@ -67,13 +74,21 @@ index 0000000..a9d763d 100644
    buildDirectories: [{
      native: {
        buildDirectoryPath: '/worker/build',
-@@ -26,8 +24,10 @@ local common = import 'common.libsonnet';
+@@ -19,6 +20,7 @@ local common = import 'common.libsonnet';
+     runners: [{
+       endpoint: { address: 'unix:///worker/runner' },
+       concurrency: 8,
++      instanceNamePrefix: 'hardlinking',
+       platform: {
+         properties: [
+           { name: 'OSFamily', value: 'linux' },
+@@ -26,8 +28,10 @@ local common = import 'common.libsonnet';
          ],
        },
        workerId: {
 -        'pod': std.extVar("POD_NAME"),
 -        'node': std.extVar("NODE_NAME")
-+        datacenter: 'paris',
++        datacenter: 'linkoping',
 +        rack: '4',
 +        slot: '15',
 +        hostname: 'ubuntu-worker.example.com',

--- a/tools/github_workflows/workflows_template.libsonnet
+++ b/tools/github_workflows/workflows_template.libsonnet
@@ -96,8 +96,8 @@
           run: 'bazel build //tools/github_workflows && cp bazel-bin/tools/github_workflows/*.yaml .github/workflows',
         },
         {
-          name: 'DISABLED: Check the diff between docker-compose and Kubernetes configs',
-          run: 'true || tools/diff-docker-and-k8s-configs.sh > tools/expected-docker-and-k8s-configs.diff',
+          name: 'Check the diff between docker-compose and Kubernetes configs',
+          run: 'tools/diff-docker-and-k8s-configs.sh > tools/expected-docker-and-k8s-configs.diff',
         },
         {
           name: 'Test style conformance',


### PR DESCRIPTION
This reverts commit `59d809ecf4f6522d39617b5965f21678ed5e8c3d`, _Temporarily disable the k8s vs docker config diff check_.

The script was disabled while introducing FUSE in the docker-compose deployment.