### PR TITLE
Auto update container images

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -40,6 +40,10 @@
                "run": "tools/diff-docker-and-k8s-configs.sh > tools/expected-docker-and-k8s-configs.diff"
             },
             {
+               "name": "Update versions of the container images",
+               "run": "tools/update-container-image-versions.sh"
+            },
+            {
                "name": "Test style conformance",
                "run": "git diff --exit-code HEAD --"
             },

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -40,6 +40,10 @@
                "run": "tools/diff-docker-and-k8s-configs.sh > tools/expected-docker-and-k8s-configs.diff"
             },
             {
+               "name": "Update versions of the container images",
+               "run": "tools/update-container-image-versions.sh"
+            },
+            {
                "name": "Test style conformance",
                "run": "git diff --exit-code HEAD --"
             },

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,29 +1,3 @@
-# Update images from the github archive for each bump of `bb-*`
-# Take the version from `go.mod`, with the date field
-# and a hash truncated to seven characters.
-# The date separates the day and the time segment with a "T"
-# and must end with "Z".
-#
-# Example:
-#
-#   'go.mod' and 'docker-compose.yml'
-#   github.com/buildbarn/bb-browser v0.0.0-20230906070406-881fd822f75e
-#   github.com/buildbarn/bb-browser         v0.0.0-20230906 070406 -881fd822f75e
-#     browser.image:  ghcr.io/buildbarn/bb-browser:20230906T070406Z-881fd82
-#             differences: t, z and truncated hash.        ^      ^        ^^^^^
-#
-# The following modules give these images respectively:
-#
-#   github.com/buildbarn/bb-remote-execution v0.0.0-20230905173453-70efb72857b0
-#     worker-fuse-ubuntu22-04.image
-#     worker-hardlinking-ubuntu22-04.image
-#     runner-installer.image
-#
-#   github.com/buildbarn/bb-storage v0.0.0-20230905110346-c04246b462b6
-#     frontend.image
-#     storage-{0,1}.image
-#
-# It is possible to create script that automatically updates the images.
 version: '3'
 services:
   frontend:

--- a/kubernetes/browser.yaml
+++ b/kubernetes/browser.yaml
@@ -14,7 +14,7 @@ spec:
         app: browser
     spec:
       containers:
-      - image: buildbarn/bb-browser:20230208T101541Z-73a5362
+      - image: ghcr.io/buildbarn/bb-browser:20230906T070406Z-881fd82
         args:
         - /config/browser.jsonnet
         name: browser

--- a/kubernetes/frontend.yaml
+++ b/kubernetes/frontend.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
       - args:
         - /config/frontend.jsonnet
-        image: buildbarn/bb-storage:20230208T220714Z-fd356c8
+        image: ghcr.io/buildbarn/bb-storage:20230905T110346Z-c04246b
         name: storage
         ports:
         - containerPort: 8980

--- a/kubernetes/scheduler.yaml
+++ b/kubernetes/scheduler.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - args:
         - /config/scheduler.jsonnet
-        image: buildbarn/bb-scheduler:20230213T172655Z-e0ae60c
+        image: ghcr.io/buildbarn/bb-scheduler:20230905T173453Z-70efb72
         name: scheduler
         ports:
         - containerPort: 8982

--- a/kubernetes/storage.yaml
+++ b/kubernetes/storage.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
       - args:
         - /config/storage.jsonnet
-        image: buildbarn/bb-storage:20230208T220714Z-fd356c8
+        image: ghcr.io/buildbarn/bb-storage:20230905T110346Z-c04246b
         name: storage
         ports:
         - containerPort: 8981

--- a/kubernetes/worker-ubuntu22-04.yaml
+++ b/kubernetes/worker-ubuntu22-04.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - args:
         - /config/worker-ubuntu22-04.jsonnet
-        image: buildbarn/bb-worker:20230213T172655Z-e0ae60c
+        image: ghcr.io/buildbarn/bb-worker:20230905T173453Z-70efb72
         name: worker
         volumeMounts:
         - mountPath: /config/
@@ -55,7 +55,7 @@ spec:
           readOnly: true
       initContainers:
       - name: bb-runner-installer
-        image: buildbarn/bb-runner-installer:20230213T172655Z-e0ae60c
+        image: ghcr.io/buildbarn/bb-runner-installer:20230905T173453Z-70efb72
         volumeMounts:
         - mountPath: /bb/
           name: bb-runner

--- a/tools/github_workflows/workflows_template.libsonnet
+++ b/tools/github_workflows/workflows_template.libsonnet
@@ -100,6 +100,10 @@
           run: 'tools/diff-docker-and-k8s-configs.sh > tools/expected-docker-and-k8s-configs.diff',
         },
         {
+          name: 'Update versions of the container images',
+          run: 'tools/update-container-image-versions.sh',
+        },
+        {
           name: 'Test style conformance',
           run: 'git diff --exit-code HEAD --',
         },

--- a/tools/update-container-image-versions.sh
+++ b/tools/update-container-image-versions.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+# Updates the image version in the Docker Compose and Kubernetes deployments.
+#
+# Run this script as soon as go.mod has been updated.
+#
+# The image versions are extracted from `go.mod`, with the date field
+# and a hash truncated to seven characters.
+# The date separates the day and the time segment with a "T"
+# and appends "Z".
+#
+# Example:
+#
+#   'go.mod' and 'docker-compose.yml'
+#   github.com/buildbarn/bb-browser v0.0.0-20230906070406-881fd822f75e
+#   github.com/buildbarn/bb-browser         v0.0.0-20230906 070406 -881fd822f75e
+#     browser.image:  ghcr.io/buildbarn/bb-browser:20230906T070406Z-881fd82
+#             differences: T, Z and truncated hash.        ^      ^        ^^^^^
+
+get_image_version() {
+    repo="$1"
+    grep -E "github\.com/buildbarn/${repo}" go.mod \
+        | sed 's,.* v0.0.0-\([0-9]\{8\}\)\([0-9]\{6\}\)-\([0-9a-f]\{7\}\)[0-9a-f]\+,\1T\2Z-\3,'
+}
+
+update_image_version() {
+    new_version="$1"
+    image_name="$2"
+    sed -i "s,\(image: ghcr\.io/buildbarn/${image_name}:\)\S*,\1${new_version}," \
+        docker-compose/docker-compose.yml kubernetes/*.yaml
+}
+
+bb_browser_version=$(get_image_version bb-browser)
+bb_remote_execution_version=$(get_image_version bb-remote-execution)
+bb_storage_version=$(get_image_version bb-storage)
+
+update_image_version "$bb_browser_version" bb-browser
+update_image_version "$bb_remote_execution_version" bb-runner-installer
+update_image_version "$bb_remote_execution_version" bb-scheduler
+update_image_version "$bb_remote_execution_version" bb-worker
+update_image_version "$bb_storage_version" bb-storage


### PR DESCRIPTION
Add `tools/update-container-image-versions.sh` to update the image versions in the Docker Compose and Kubernetes deployments based on the versions in `go.mod`.