### PR TITLE
Remove 'ineffassign'

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -52,10 +52,6 @@
                "run": "bazel run @org_golang_x_lint//golint -- -set_exit_status $(pwd)/..."
             },
             {
-               "name": "Check for ineffective assignments",
-               "run": "bazel run @com_github_gordonklaus_ineffassign//:ineffassign $(pwd)"
-            },
-            {
                "name": "Test bare deployment",
                "run": "tools/test-deployment-bare.sh"
             },

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -52,10 +52,6 @@
                "run": "bazel run @org_golang_x_lint//golint -- -set_exit_status $(pwd)/..."
             },
             {
-               "name": "Check for ineffective assignments",
-               "run": "bazel run @com_github_gordonklaus_ineffassign//:ineffassign $(pwd)"
-            },
-            {
                "name": "Test bare deployment",
                "run": "tools/test-deployment-bare.sh"
             },

--- a/dummy_for_dependencies.go
+++ b/dummy_for_dependencies.go
@@ -14,6 +14,5 @@ import (
 	"github.com/buildbarn/bb-remote-execution/cmd/bb_scheduler"
 	"github.com/buildbarn/bb-remote-execution/cmd/bb_worker"
 	"github.com/buildbarn/bb-storage/cmd/bb_storage"
-	"github.com/gordonklaus/ineffassign" // GitHub Workflow
-	"mvdan.cc/gofumpt"                   // GitHub Workflow
+	"mvdan.cc/gofumpt" // GitHub Workflow
 )

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/buildbarn/bb-deployments
 
 go 1.20
 
-// Use the same version as in bb-storage.
-replace github.com/gordonklaus/ineffassign => github.com/gordonklaus/ineffassign v0.0.0-20201223204552-cba2d2a1d5d9
-
 // https://github.com/grpc-ecosystem/grpc-gateway/commit/5f9757f31b517d98095209636b2b88cd6326572f
 replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.1
 
@@ -16,7 +13,6 @@ require (
 	github.com/buildbarn/bb-browser v0.0.0-20231103134227-794e38071d7a
 	github.com/buildbarn/bb-remote-execution v0.0.0-20231114140735-33a02620cd6e
 	github.com/buildbarn/bb-storage v0.0.0-20231111202247-ece87ab6dc2a
-	github.com/gordonklaus/ineffassign v0.1.0
 	mvdan.cc/gofumpt v0.5.0
 )
 
@@ -27,7 +23,6 @@ require (
 	cloud.google.com/go/iam v1.1.5 // indirect
 	cloud.google.com/go/longrunning v0.5.4 // indirect
 	cloud.google.com/go/storage v1.35.1 // indirect
-	dmitri.shuralyov.com/go/generated v0.0.0-20230423232055-e1de01541153 // indirect
 	git.sr.ht/~sbinet/gg v0.5.0 // indirect
 	github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b // indirect
 	github.com/aohorodnyk/mimeheader v0.0.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ cloud.google.com/go/longrunning v0.5.4 h1:w8xEcbZodnA2BbW6sVirkkoC+1gP8wS57EUUgG
 cloud.google.com/go/longrunning v0.5.4/go.mod h1:zqNVncI0BOP8ST6XQD1+VcvuShMmq7+xFSzOL++V0dI=
 cloud.google.com/go/storage v1.35.1 h1:B59ahL//eDfx2IIKFBeT5Atm9wnNmj3+8xG/W4WB//w=
 cloud.google.com/go/storage v1.35.1/go.mod h1:M6M/3V/D3KpzMTJyPOR/HU6n2Si5QdaXYEsng2xgOs8=
-dmitri.shuralyov.com/go/generated v0.0.0-20230423232055-e1de01541153 h1:TFutR9iGKTFjtYIYVhfMq94vxB0mACalKPHeOGH66gk=
-dmitri.shuralyov.com/go/generated v0.0.0-20230423232055-e1de01541153/go.mod h1:WG7q7swWsS2f9PYpt5DoEP/EBYWx8We5UoRltn9vJl8=
 git.sr.ht/~sbinet/cmpimg v0.1.0 h1:E0zPRk2muWuCqSKSVZIWsgtU9pjsw3eKHi8VmQeScxo=
 git.sr.ht/~sbinet/gg v0.5.0 h1:6V43j30HM623V329xA9Ntq+WJrMjDxRjuAB1LFWF5m8=
 git.sr.ht/~sbinet/gg v0.5.0/go.mod h1:G2C0eRESqlKhS7ErsNey6HHrqU1PwsnCQlekFi9Q2Oo=
@@ -165,8 +163,6 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
-github.com/gordonklaus/ineffassign v0.0.0-20201223204552-cba2d2a1d5d9 h1:ISiYmLMC4o0lTlN31qYlz2NTpU8Pgrv54nVAJMOf+Fw=
-github.com/gordonklaus/ineffassign v0.0.0-20201223204552-cba2d2a1d5d9/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=

--- a/go_dependencies.bzl
+++ b/go_dependencies.bzl
@@ -507,9 +507,8 @@ def go_dependencies():
     go_repository(
         name = "com_github_gordonklaus_ineffassign",
         importpath = "github.com/gordonklaus/ineffassign",
-        replace = "github.com/gordonklaus/ineffassign",
-        sum = "h1:ISiYmLMC4o0lTlN31qYlz2NTpU8Pgrv54nVAJMOf+Fw=",
-        version = "v0.0.0-20201223204552-cba2d2a1d5d9",
+        sum = "h1:PVRE9d4AQKmbelZ7emNig1+NT27DUmKZn5qXxfio54U=",
+        version = "v0.0.0-20210914165742-4cc7213b9bc8",
     )
     go_repository(
         name = "com_github_gorilla_mux",
@@ -1501,12 +1500,6 @@ def go_dependencies():
         importpath = "cloud.google.com/go/workflows",
         sum = "h1:qocsqETmLAl34mSa01hKZjcqAvt699gaoFbooGGMvaM=",
         version = "v1.12.3",
-    )
-    go_repository(
-        name = "com_shuralyov_dmitri_go_generated",
-        importpath = "dmitri.shuralyov.com/go/generated",
-        sum = "h1:TFutR9iGKTFjtYIYVhfMq94vxB0mACalKPHeOGH66gk=",
-        version = "v0.0.0-20230423232055-e1de01541153",
     )
     go_repository(
         name = "ht_sr_git_sbinet_cmpimg",

--- a/tools/github_workflows/workflows_template.libsonnet
+++ b/tools/github_workflows/workflows_template.libsonnet
@@ -112,10 +112,6 @@
           run: 'bazel run @org_golang_x_lint//golint -- -set_exit_status $(pwd)/...',
         },
         {
-          name: 'Check for ineffective assignments',
-          run: 'bazel run @com_github_gordonklaus_ineffassign//:ineffassign $(pwd)',
-        },
-        {
           name: 'Test bare deployment',
           run: 'tools/test-deployment-bare.sh',
         },


### PR DESCRIPTION
1ac7fe02583bb2e902c74da0fa7037250557cd57 Remove our use of ineffassign

    Recent versions of the Go compiler have become better at reporting
    ineffective assignments. We haven't seen any errors generated by
    ineffassign that weren't caught by the compiler in years.