### PR TITLE
Upgrade to docker compose V2

### DIFF
--- a/docker-compose/run.sh
+++ b/docker-compose/run.sh
@@ -41,4 +41,4 @@ else
 fi
 
 setup
-docker-compose up "$@"
+docker compose up "$@"


### PR DESCRIPTION
As stated in the [docker release notes](https://docs.docker.com/compose/release-notes/) "Effective July 2023, Compose V1 stopped receiving updates". Following the [migration guidelines](https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose), this PR switches to V2 of docker compose.