### PR TITLE
Set newBlocks to 3 instead of 1

### DIFF
--- a/bare/config/storage.jsonnet
+++ b/bare/config/storage.jsonnet
@@ -20,7 +20,7 @@ local common = import 'common.libsonnet';
         keyLocationMapMaximumPutAttempts: 32,
         oldBlocks: 8,
         currentBlocks: 24,
-        newBlocks: 1,
+        newBlocks: 3,
         blocksOnBlockDevice: {
           source: {
             file: {

--- a/docker-compose/config/storage.jsonnet
+++ b/docker-compose/config/storage.jsonnet
@@ -20,7 +20,7 @@ local common = import 'common.libsonnet';
         keyLocationMapMaximumPutAttempts: 32,
         oldBlocks: 8,
         currentBlocks: 24,
-        newBlocks: 1,
+        newBlocks: 3,
         blocksOnBlockDevice: {
           source: {
             file: {

--- a/docker-compose/config/worker-fuse-ubuntu22-04.jsonnet
+++ b/docker-compose/config/worker-fuse-ubuntu22-04.jsonnet
@@ -20,7 +20,7 @@ local common = import 'common.libsonnet';
             keyLocationMapMaximumPutAttempts: 32,
             oldBlocks: 8,
             currentBlocks: 24,
-            newBlocks: 1,
+            newBlocks: 3,
             blocksOnBlockDevice: {
               source: {
                 file: {

--- a/kubernetes/config/storage.jsonnet
+++ b/kubernetes/config/storage.jsonnet
@@ -20,7 +20,7 @@ local common = import 'common.libsonnet';
         keyLocationMapMaximumPutAttempts: 32,
         oldBlocks: 8,
         currentBlocks: 24,
-        newBlocks: 1,
+        newBlocks: 3,
         blocksOnBlockDevice: {
           source: {
             file: {


### PR DESCRIPTION
In blobstore.proto, the recommended value for newBlocks is 3 for CAS and 1 for AC. Let's use that in the examples as well.