### PR TITLE
Kubernetes test: wait for 'traefik' to start

### DIFF
--- a/tools/test-deployment-kubernetes
+++ b/tools/test-deployment-kubernetes
@@ -34,6 +34,7 @@ kubectl rollout status --watch --namespace=buildbarn --timeout=300s deployment
 kubectl rollout status --watch --namespace=kube-system --timeout=300s statefulset
 kubectl rollout status --watch --namespace=kube-system --timeout=300s deployment
 kubectl rollout status --watch --namespace=kube-system --timeout=300s daemonset
+kubectl wait -n kube-system --for=jsonpath='{.status.loadBalancer.ingress}' service/traefik
 
 # Find the frontend.
 bb_frontend_ip=$(kubectl get service --namespace=buildbarn frontend -o json | jq --raw-output '.status.loadBalancer.ingress[0].ip')


### PR DESCRIPTION
This avoids rare race condition failures.

Use prebuilt protoc toolchain · buildbarn/bb-deployments@a2c16d0
https://github.com/buildbarn/bb-deployments/actions/runs/10471995753/job/29000455997?pr=139

    ...
    ++ kubectl get service --namespace=buildbarn frontend -o json
    ++ jq --raw-output '.status.loadBalancer.ingress[0].ip'
    + bb_frontend_ip=172.20.0.2
    + bb_frontend_address=grpc://172.20.0.2:8980
    ++ kubectl get service --namespace=kube-system traefik -o json
    ++ jq --raw-output '.status.loadBalancer.ingress[0].ip'
    Error from server (NotFound): services "traefik" not found
    ...