### PR TITLE
Rename metric name 'old_current_new' to 'old_new_current'

### DIFF
--- a/monitoring/grafana/centralized-storage.jsonnet
+++ b/monitoring/grafana/centralized-storage.jsonnet
@@ -29,17 +29,17 @@ simpledash.dashboard(
   rows=[
     showRetentionRow(
       title='Per-replica worst shard retention: whether it is safe to restart the other replica',
-      targetMetric='kubernetes_replica_storage_type:buildbarn_blobstore_old_new_current_location_blob_map_last_removed_old_block_insertion_time_seconds:min',
+      targetMetric='kubernetes_replica_storage_type:buildbarn_blobstore_old_current_new_location_blob_map_last_removed_old_block_insertion_time_seconds:min',
       targetLegendFormat='{{kubernetes_replica}}',
     ),
     showRetentionRow(
       title='Per-shard best replica retention: amount of data accessible right now',
-      targetMetric='kubernetes_shard_storage_type:buildbarn_blobstore_old_new_current_location_blob_map_last_removed_old_block_insertion_time_seconds:max',
+      targetMetric='kubernetes_shard_storage_type:buildbarn_blobstore_old_current_new_location_blob_map_last_removed_old_block_insertion_time_seconds:max',
       targetLegendFormat='{{kubernetes_shard}}',
     ),
     showRetentionRow(
       title='Per-shard worst replica retention: amount of data to remain accessible if a replica were to crash',
-      targetMetric='kubernetes_shard_storage_type:buildbarn_blobstore_old_new_current_location_blob_map_last_removed_old_block_insertion_time_seconds:min',
+      targetMetric='kubernetes_shard_storage_type:buildbarn_blobstore_old_current_new_location_blob_map_last_removed_old_block_insertion_time_seconds:min',
       targetLegendFormat='{{kubernetes_shard}}',
     ),
 

--- a/monitoring/prometheus/recording-rules.jsonnet
+++ b/monitoring/prometheus/recording-rules.jsonnet
@@ -35,20 +35,20 @@
 
         // Statistics on retention of centralized storage.
         {
-          expr: 'min(time() - buildbarn_blobstore_old_new_current_location_blob_map_last_removed_old_block_insertion_time_seconds{job="kubernetes-service-endpoints",kubernetes_service="bb-storage"}) by (kubernetes_replica, kubernetes_shard, storage_type)',
-          record: 'kubernetes_replica_kubernetes_shard_storage_type:buildbarn_blobstore_old_new_current_location_blob_map_last_removed_old_block_insertion_time_seconds',
+          expr: 'min(time() - buildbarn_blobstore_old_current_new_location_blob_map_last_removed_old_block_insertion_time_seconds{job="kubernetes-service-endpoints",kubernetes_service="bb-storage"}) by (kubernetes_replica, kubernetes_shard, storage_type)',
+          record: 'kubernetes_replica_kubernetes_shard_storage_type:buildbarn_blobstore_old_current_new_location_blob_map_last_removed_old_block_insertion_time_seconds',
         },
         {
-          expr: 'min(kubernetes_replica_kubernetes_shard_storage_type:buildbarn_blobstore_old_new_current_location_blob_map_last_removed_old_block_insertion_time_seconds) by (kubernetes_replica, storage_type)',
-          record: 'kubernetes_replica_storage_type:buildbarn_blobstore_old_new_current_location_blob_map_last_removed_old_block_insertion_time_seconds:min',
+          expr: 'min(kubernetes_replica_kubernetes_shard_storage_type:buildbarn_blobstore_old_current_new_location_blob_map_last_removed_old_block_insertion_time_seconds) by (kubernetes_replica, storage_type)',
+          record: 'kubernetes_replica_storage_type:buildbarn_blobstore_old_current_new_location_blob_map_last_removed_old_block_insertion_time_seconds:min',
         },
         {
-          expr: 'max(kubernetes_replica_kubernetes_shard_storage_type:buildbarn_blobstore_old_new_current_location_blob_map_last_removed_old_block_insertion_time_seconds) by (kubernetes_shard, storage_type)',
-          record: 'kubernetes_shard_storage_type:buildbarn_blobstore_old_new_current_location_blob_map_last_removed_old_block_insertion_time_seconds:max',
+          expr: 'max(kubernetes_replica_kubernetes_shard_storage_type:buildbarn_blobstore_old_current_new_location_blob_map_last_removed_old_block_insertion_time_seconds) by (kubernetes_shard, storage_type)',
+          record: 'kubernetes_shard_storage_type:buildbarn_blobstore_old_current_new_location_blob_map_last_removed_old_block_insertion_time_seconds:max',
         },
         {
-          expr: 'min(kubernetes_replica_kubernetes_shard_storage_type:buildbarn_blobstore_old_new_current_location_blob_map_last_removed_old_block_insertion_time_seconds) by (kubernetes_shard, storage_type)',
-          record: 'kubernetes_shard_storage_type:buildbarn_blobstore_old_new_current_location_blob_map_last_removed_old_block_insertion_time_seconds:min',
+          expr: 'min(kubernetes_replica_kubernetes_shard_storage_type:buildbarn_blobstore_old_current_new_location_blob_map_last_removed_old_block_insertion_time_seconds) by (kubernetes_shard, storage_type)',
+          record: 'kubernetes_shard_storage_type:buildbarn_blobstore_old_current_new_location_blob_map_last_removed_old_block_insertion_time_seconds:min',
         },
         {
           expr: 'sum(irate(buildbarn_blobstore_hashing_key_location_map_get_attempts_count{job="kubernetes-service-endpoints",kubernetes_service="bb-storage"}[1m])) by (storage_type, outcome)',


### PR DESCRIPTION
This matches the following commit in bb-storage, where the typo was fixed. This will fix the KLM retention graphs in Grafana.

    commit c04246b462b6bc68ae9b111d2024c57db439b0b6
    Document how to tune the size of LocalBlobAccess

    ...

    While there, fix a typo in the metric name. It should be named
    'old_current_new' to match the implementation, not 'old_new_current'.