### PR TITLE
Convert remote_config_sh to bazel mod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,6 +16,7 @@ bazel_dep(name = "opentelemetry-proto", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "protobuf", version = "29.3")
 bazel_dep(name = "remote_config_cc")
+bazel_dep(name = "remote_config_sh")
 bazel_dep(name = "rules_antlr")
 bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "rules_go", version = "0.53.0")
@@ -94,6 +95,11 @@ http_archive(
 local_path_override(
     module_name = "remote_config_cc",
     path = "tools/remote-toolchains/ubuntu-act-22-04/local_config_cc",
+)
+
+local_path_override(
+    module_name = "remote_config_sh",
+    path = "tools/remote-toolchains/ubuntu-act-22-04/local_config_sh",
 )
 
 git_override(

--- a/tools/remote-toolchains/ubuntu-act-22-04/local_config_sh/MODULE.bazel
+++ b/tools/remote-toolchains/ubuntu-act-22-04/local_config_sh/MODULE.bazel
@@ -1,0 +1,3 @@
+module(name = "remote_config_sh")
+
+bazel_dep(name = "rules_shell", version = "0.3.0")

--- a/tools/remote-toolchains/ubuntu-act-22-04/local_config_sh/WORKSPACE
+++ b/tools/remote-toolchains/ubuntu-act-22-04/local_config_sh/WORKSPACE
@@ -1,2 +1,0 @@
-# DO NOT EDIT: automatically generated WORKSPACE file for sh_config rule
-workspace(name = "local_config_sh")


### PR DESCRIPTION
When migrating to bazel mod the repository remote_config_sh was not converted to bazel mod format.

This fix brings it back in.