### PR TITLE
Fix flaky Windows ci job

### DIFF
--- a/tools/test-deployment-bare.sh
+++ b/tools/test-deployment-bare.sh
@@ -72,6 +72,10 @@ grep -E '^INFO: [0-9]+ processes: .*[0-9]+ remote[.,]' \
 # --- Check that we get cache hit even after rebooting the server ---
 kill -s $kill_sig "$buildbarn_pid"
 wait "$buildbarn_pid" || true
+# On Windows, wait doesn't wait for the bare.exe process to exit.
+# The batch wrapper terminates directly. Give bb-storage some time to write down the persistent state.
+# TODO: 2026-06-22 Make sure wait works and remove the sleep.
+sleep 2
 $script_exec 2>"${bare_output}" &
 buildbarn_pid=$!
 sleep 5


### PR DESCRIPTION
Then terminating the bare deployment, bb-storage didn't always write the persistent state file. Fix that.